### PR TITLE
Add souvenir skins and a speacial note

### DIFF
--- a/services/main.js
+++ b/services/main.js
@@ -240,6 +240,26 @@ export const loadSkinsByCrates = () => {
 
     state.skinsByCrates = {
         ...Object.values(revolvingLootLists).reduce((items, item) => {
+            if (item === 'crate_dhw13_promo') {
+                // Source: https://counterstrike.fandom.com/wiki/DreamHack_2013_Souvenir_Package
+                items[item] = ['set_dust_2', 'set_safehouse', 'set_italy', 'set_lake', 'set_train', 'set_mirage'].flatMap(set => 
+                    Object.keys(extractItems(set, clientLootLists)).map(getItemFromKey)
+                )
+
+                items[item].push(getItemFromKey('[sp_tape]weapon_revolver'))
+
+                return items
+            }
+
+            if (item === 'crate_ems14_promo') {
+                // I assume the drops are the same as "DreamHack 2013" but the "R8 Revolver | Bone Mask"
+                items[item] = ['set_dust_2', 'set_safehouse', 'set_italy', 'set_lake', 'set_train', 'set_mirage'].flatMap(set => 
+                    Object.keys(extractItems(set, clientLootLists)).map(getItemFromKey)
+                )
+
+                return items
+            }
+
             items[item] = Object.keys(extractItems(item, clientLootLists)).map(
                 getItemFromKey
             );
@@ -315,15 +335,7 @@ export const loadyCratesBySkins = () => {
 export const loadSkinsByCollections = () => {
     state.skinsByCollections = Object.entries(state.itemsGame.item_sets).reduce(
         (items, [key, value]) => {
-            items[key] = Object.keys(value.items).map((item) => {
-                const ftt = getItemFromKey(item);
-
-                if (ftt == null) {
-                    console.log(item);
-                }
-
-                return ftt;
-            });
+            items[key] = Object.keys(value.items).map((item) => getItemFromKey(item));
             return items;
         },
         {}

--- a/utils/specialNotes.json
+++ b/utils/specialNotes.json
@@ -76,5 +76,11 @@
             "source": "https://www.hltv.org/news/22359/tyloo-confirm-major-absence-replacement-to-come-from-asia-minor",
             "text": "The capsule that contains this was removed from the sale after Flash Gaming replaced Tyloo in the Boston 2018 major due to visa issues."
         }
+    ],
+    "skin-4194412": [
+        {
+            "source": "https://counterstrike.fandom.com/wiki/DreamHack_2013_Souvenir_Package#:~:text=It%20also%20has%20the%20potential%20to%20drop%20a%20bugged%20R8%20Revolver%20%7C%20Bone%20Mask%20from%20the%20Bank%20Collection%2C%20which%20was%20added%20to%20the%20package%20by%20mistake%20on%20December%208th%2C%202015%20in%20the%20R8%20Revolver%20update%2C%20when%20the%20R8%20Revolver%20%7C%20Amber%20Fade%20from%20the%20Dust%20II%20Collection%20was%20added.",
+            "text": "Was added to the 'DreamHack 2013 Souvenir Package' by mistake making it the only souvenir in the Bank Collection."
+        }
     ]
 }


### PR DESCRIPTION
Add "DreamHack 2013 Souvenir Package" and "EMS One 2014 Souvenir Package" skins and a special note.

Source:
- https://counterstrike.fandom.com/wiki/DreamHack_2013_Souvenir_Package
- https://csgoskins.gg/containers/dreamhack-2013-souvenir-package
- https://wiki.cs.money/cases/dreamhack-2013-souvenir-package