### PR TITLE
Fix: CPH issue

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -368,7 +368,7 @@ export const getCollectibleRarity = (prefab) => {
             case "rio2022_tournament_pass_prefab":
             case "stockh2021_tournament_pass_prefab":
             case "paris2023_tournament_pass_prefab":
-			case "cph2024_tournament_pass_prefab":
+            case "cph2024_tournament_pass_prefab":
             case "season_pass":
             case "season_tiers":
                 return "rarity_common";

--- a/utils/index.js
+++ b/utils/index.js
@@ -378,6 +378,7 @@ export const getCollectibleRarity = (prefab) => {
             case "rio2022_tournament_journal_prefab":
             case "stockh2021_tournament_journal_prefab":
             case "paris2023_tournament_journal_prefab":
+            case "cph2024_tournament_journal_prefab":
             case "collectible_untradable_coin":
             case "majors_trophy":
             case "map_token":

--- a/utils/index.js
+++ b/utils/index.js
@@ -368,6 +368,7 @@ export const getCollectibleRarity = (prefab) => {
             case "rio2022_tournament_pass_prefab":
             case "stockh2021_tournament_pass_prefab":
             case "paris2023_tournament_pass_prefab":
+			case "cph2024_tournament_pass_prefab":
             case "season_pass":
             case "season_tiers":
                 return "rarity_common";


### PR DESCRIPTION
```
{
  item_name: '#CSGO_TournamentPass_cph2024',
  name: 'tournament_pass_cph2024',
  item_description: '#CSGO_TournamentPass_cph2024_Desc',
  image_inventory: 'econ/status_icons/pgl_pickem_2024_pass',
  prefab: 'cph2024_tournament_pass_prefab cph2024_tournament_steamtv_items',
  object_id: '4916',
  item_name_prefab: undefined,
  item_description_prefab: undefined,
  used_by_classes: undefined
}
TypeError: Cannot read properties of null (reading 'toLowerCase')
    at getRarityColor (file:///home/scripts/cs2-item-parser/utils/index.js:404:13)
    at parseItem (file:///home/scripts/cs2-item-parser/services/collectibles.js:118:11)
    at Array.map (<anonymous>)
    at getCollectibles (file:///home/scripts/cs2-item-parser/services/collectibles.js:141:4)
    at processUpdate (file:///home/scripts/cs2-item-parser/index.js:217:4)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async SteamUser.<anonymous> (file:///home/scripts/cs2-item-parser/index.js:329:2)
 ```