### PR TITLE
Add support for new keychain items

### DIFF
--- a/group.js
+++ b/group.js
@@ -14,6 +14,7 @@ const inputFilePathsTemplate = [
     "./public/api/{lang}/patches.json",
     "./public/api/{lang}/skins_not_grouped.json",
     "./public/api/{lang}/stickers.json",
+    "./public/api/{lang}/keychains.json",
     "./public/api/{lang}/tools.json",
 ];
 

--- a/services/keychains.js
+++ b/services/keychains.js
@@ -1,0 +1,60 @@
+import { saveDataJson } from "../utils/saveDataJson.js";
+import { $t, languageData } from "./translations.js";
+import { state } from "./main.js";
+import { getImageUrl } from "../constants.js";
+import { getRarityColor } from "../utils/index.js";
+
+const isKeychain = (item) => {
+    if (!item.loc_name.startsWith("#keychain_")) {
+        return false;
+    }
+
+    return true;
+};
+
+const getDescription = (item) => {
+    let msg = $t("CSGO_Tool_Keychain_Desc");
+    let desc = $t(item.loc_description);
+    if (desc && desc.length > 0 && item.loc_description !== `#${desc}`) {
+        msg = `${msg}<br><br>${desc}`;
+    }
+    return msg;
+};
+
+const getMarketHashName = (item) => {
+    return `${$t("CSGO_Tool_Keychain", true)} | ${$t(item.loc_name, true)}`;
+};
+
+const parseItem = (item) => {
+    const image = getImageUrl(
+        `${item.image_inventory.toLowerCase()}`
+    );
+
+    return {
+        id: `keychain-${item.object_id}`,
+        name: `${$t("CSGO_Tool_Keychain")} | ${$t(item.loc_name)}`,
+        description: getDescription(item),
+        rarity: item.item_rarity
+        ? {
+              id: `rarity_${item.item_rarity}`,
+              name: $t(`rarity_${item.item_rarity}`),
+              color: getRarityColor(`rarity_${item.item_rarity}`),
+          }
+        : {
+              id: "rarity_default",
+              name: $t("rarity_default"),
+              color: getRarityColor("rarity_default"),
+          },
+        market_hash_name: getMarketHashName(item),
+        image,
+    };
+};
+
+export const getKeychains = () => {
+    const { keychainDefinitions } = state;
+    const { folder } = languageData;
+
+    const keychains = keychainDefinitions.filter(isKeychain).map(parseItem);
+
+    saveDataJson(`./public/api/${folder}/keychains.json`, keychains);
+};

--- a/services/main.js
+++ b/services/main.js
@@ -53,6 +53,19 @@ export const loadStickerKits = () => {
     );
 };
 
+export const loadKeychainDefinitions = () => {
+    state.keychainDefinitions = Object.entries(state.itemsGame.keychain_definitions).map(
+        ([key, item]) => ({
+            ...item,
+            object_id: key,
+        })
+    )
+
+    state.keychainDefinitionsObj = Object.fromEntries(
+        state.keychainDefinitions.map((item) => [item.name, item])
+    );
+};
+
 export const loadItems = () => {
     state.items = Object.entries(state.itemsGame.items).reduce(
         (acc, [key, value]) => {
@@ -723,6 +736,7 @@ export const loadData = async () => {
     loadItems();
     loadItemSets();
     loadStickerKits();
+    loadKeychainDefinitions();
     loadPaintKits();
     loadMusicDefinitions();
     loadClientLootLists();

--- a/update.js
+++ b/update.js
@@ -10,6 +10,7 @@ import { loadTranslations } from "./services/translations.js";
 import { getGraffiti } from "./services/graffiti.js";
 import { getPatches } from "./services/patches.js";
 import { getStickers } from "./services/stickers.js";
+import { getKeychains } from "./services/keychains.js";
 import { getSkins } from "./services/skins.js";
 import { LANGUAGES_URL } from "./constants.js";
 import { getMusicKits } from "./services/musicKits.js";
@@ -55,6 +56,7 @@ for (const language of LANGUAGES_URL) {
         getSkins();
         getSkinsNotGrouped();
         getStickers();
+        getKeychains();
         getTools();
     } catch (error) {
         console.log(error);


### PR DESCRIPTION
Ran it to validate that it works. Here is an example item from the new `keychains.json`:

```js
{
    "id": "keychain-1",
    "name": "Charm | Lil' Ava",
    "description": "This charm can be attached to any weapon you own. Each attached charm can be detached by using a Charm Detachment. Detached charms will be returned to your inventory.",
    "rarity": {
      "id": "rarity_rare",
      "name": "High Grade",
      "color": "#4b69ff"
    },
    "market_hash_name": "Charm | Lil' Ava",
    "image": "https://raw.githubusercontent.com/ByMykel/counter-strike-image-tracker/main/static/panorama/images/econ/keychains/missinglink/kc_missinglink_ava_png.png"
  }
```