### PR TITLE
Adding paint_index to others variants

### DIFF
--- a/services/agents.js
+++ b/services/agents.js
@@ -17,6 +17,7 @@ const parseItem = (item) => {
         id: `agent-${item.object_id}`,
         name: $t(item.item_name),
         description: $t(item.item_description),
+        paint_index: item.object_id,
         rarity: {
             id: `rarity_${item.item_rarity}_character`,
             name: $t(`rarity_${item.item_rarity}_character`),

--- a/services/collectibles.js
+++ b/services/collectibles.js
@@ -97,6 +97,7 @@ const parseItem = (item) => {
             : item.item_description_prefab
             ? $t(item.item_description_prefab)
             : null,
+        paint_index: item.object_id,
         rarity: {
             id: rarity,
             name: $t(rarity),

--- a/services/graffiti.js
+++ b/services/graffiti.js
@@ -50,6 +50,7 @@ const parseItemSealedGraffiti = (item) => {
                     colorKey
                 )})`,
                 description: getDescription(item),
+                paint_index: item.object_id,
                 rarity: {
                     id: `rarity_${item.item_rarity}`,
                     name: $t(`rarity_${item.item_rarity}`),

--- a/services/keychains.js
+++ b/services/keychains.js
@@ -26,6 +26,7 @@ const parseItem = (item) => {
         id: `keychain-${item.object_id}`,
         name: `${$t("CSGO_Tool_Keychain")} | ${$t(item.loc_name)}`,
         description: $t("csgo_tool_keychain_desc"),
+        paint_index: item.object_id,
         rarity: {
             id: `rarity_${item.item_rarity}`,
             name: $t(`rarity_${item.item_rarity}`),

--- a/services/musicKits.js
+++ b/services/musicKits.js
@@ -34,6 +34,7 @@ const parseItem = (item) => {
             id: `music_kit-${item.object_id}`,
             name: (exclusive || valve) ? $t(item.loc_name) : $t(item.coupon_name),
             description: $t(item.loc_description),
+            paint_index: item.object_id,
             rarity: {
                 id: "rarity_rare",
                 name: $t("rarity_rare"),
@@ -52,6 +53,7 @@ const parseItem = (item) => {
             id: `music_kit-${item.object_id}_st`,
             name: $t(`${item.coupon_name}_stattrak`),
             description: $t(item.loc_description),
+            paint_index: item.object_id,
             rarity: {
                 id: "rarity_rare",
                 name: $t("rarity_rare"),

--- a/services/patches.js
+++ b/services/patches.js
@@ -30,6 +30,7 @@ const parseItem = (item) => {
         id: `patch-${item.object_id}`,
         name: `${$t("csgo_tool_patch")} | ${$t(item.item_name)}`,
         description: getDescription(item),
+        paint_index: item.object_id,
         rarity: {
             id: `rarity_${item.item_rarity}`,
             name: $t(`rarity_${item.item_rarity}`),

--- a/services/stickers.js
+++ b/services/stickers.js
@@ -160,6 +160,7 @@ const parseItem = (item) => {
         id: `sticker-${item.object_id}`,
         name: `${$t("csgo_tool_sticker")} | ${$t(item.item_name)}`,
         description: getDescription(item),
+        paint_index: item.object_id,
         rarity: item.item_rarity
             ? {
                 id: `rarity_${item.item_rarity}`,


### PR DESCRIPTION
Adds the `paint_index` field to all collectible APIs (e.g., medals, pins, patches, etc.).

For skins I alrealdy use `paint_index` to query, but with the annother collectibles I need to parse from `id`.

### Before
```
{
  "id": "collectible-5012",
  "name": "Premier Season Two Medal",
}

```

### After
```
{
  "id": "collectible-5012",
  "name": "Premier Season Two Medal",
  "paint_index": 5012,
}
```
### Benefits

- Eliminates the need for extra parsing or regex-based workarounds.
- Improves consistency and reusability across the skin and collectible data structures.