### PR TITLE
Feature - Teams for Music Kit and Collectibles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -723,6 +723,7 @@
         name: "Sticker | Titan | Katowice 2014",
         description:
             "This item commemorates the The 2014 EMS One Katowice CS:GO Championship.This sticker can be applied to any weapon you own and can be scraped to look more worn. You can scrape the same sticker multiple times, making it a bit more worn each time, until it is removed from the weapon.",
+        "paint_index": "75",
         rarity: {
             id: "rarity_rare",
             name: "High Grade",
@@ -791,6 +792,7 @@
         name: "Charm | Lil' Ava",
         description:
             "This charm can be attached to any weapon you own. Each attached charm can be detached by using a Charm Detachment. Detached charms will be returned to your inventory.",
+        "paint_index": "1",
         rarity: {
             id: "rarity_rare",
             name: "High Grade",
@@ -1085,6 +1087,7 @@
         "id": "collectible-874",
         "name": "5 Year Veteran Coin",
         "description": "Has been a member of the Counter-Strike community for over 5 years.",
+        "paint_index": "874",
         "rarity": {
             "id": "rarity_ancient",
             "name": "Extraordinary",
@@ -1093,6 +1096,10 @@
         "type": null,
         "genuine": false,
         "market_hash_name": null,
+        team: {
+            id: "both",
+            name: "Both Teams",
+        },
         "image": "https://raw.githubusercontent.com/ByMykel/counter-strike-image-tracker/main/static/panorama/images/econ/status_icons/5yearcoin_png.png"
     }
     // ... 
@@ -1143,6 +1150,7 @@
         "id": "agent-4613",
         "name": "Bloody Darryl The Strapped | The Professionals",
         "description": "Before he was leader of the heist gang 'The Professionals' Sir Bloody Darryl was more simply called, Bloody Darryl. Still your friendly neighborhood psychopath in every sense of the word. Not actually Australian according to Australians. \\n\\n<i>I'm just gonna give them a bit of Razzle Dazzle.</i>",
+        "paint_index": "4613",
         "rarity": {
             "id": "rarity_legendary_character",
             "name": "Superior",
@@ -1210,6 +1218,7 @@
         "id": "patch-5126",
         "name": "Patch | FaZe Clan (Gold) | Stockholm 2021",
         "description": "This patch can be applied to any agent you own. Once applied, it can be removed but not recovered.",
+        "paint_index": "5126",
         "rarity": {
             "id": "rarity_mythical",
             "name": "Remarkable",
@@ -1330,6 +1339,7 @@
         "id": "music_kit-39",
         "name": "Music Kit | The Verkkars, EZ4ENCE",
         "description": "The Verkkars rise through the Finnish charts with a heart-pounding tribute to ENCE. Can it really be so EZ?",
+        "paint_index": "39",
         "rarity": {
             "id": "rarity_rare",
             "name": "High Grade",
@@ -1337,6 +1347,10 @@
         },
         "market_hash_name": "Music Kit | The Verkkars, EZ4ENCE",
         "exclusive": false,
+        team: {
+            id: "both",
+            name: "Both Teams",
+        },
         "image": "https://raw.githubusercontent.com/ByMykel/counter-strike-image-tracker/main/static/panorama/images/econ/music_kits/theverkkars_01_png.png"
     },
     // ...

--- a/services/collectibles.js
+++ b/services/collectibles.js
@@ -109,6 +109,13 @@ const parseItem = (item) => {
             ["Pass", "Pin"].includes(getType(item)) && !isAttendance
                 ? $t(item.item_name, true)
                 : null,
+        team: {
+            id: Object.keys(item.used_by_classes)[0],
+            name:
+                Object.keys(item.used_by_classes)[0] === "counter-terrorists"
+                    ? $t("inv_filter_ct")
+                    : $t("inv_filter_t"),
+        },
         image,
     };
 };

--- a/services/musicKits.js
+++ b/services/musicKits.js
@@ -61,6 +61,13 @@ const parseItem = (item) => {
             },
             market_hash_name: exclusive ? null : `StatTrak™ Music Kit | ${$t(`musickit_${item.name}`, true)}`,
             exclusive: false,
+            team: {
+                id: Object.keys(item.used_by_classes)[0],
+                name:
+                    Object.keys(item.used_by_classes)[0] === "counter-terrorists"
+                        ? $t("inv_filter_ct")
+                        : $t("inv_filter_t"),
+            },
             image,
         };
 


### PR DESCRIPTION
Hey!
My idea is to add `team` to Collectibles and Music Kits.

We have two options: detect the correct team in the existing code (by checking file metadata) or hardcode it like this:
```
team: {
    id: "both",
    name: "Both Teams",
}
```

I know all items currently default to "Both", but since I use the team field for some verifications, adding it would make things easier and the API more consistent and reusable.

In this commit, I also updated the documentation to include `paint_index`, which I added in my previous commit.