### PR TITLE
Fix double spaces in item names (  | → |)

### DIFF
--- a/services/agents.js
+++ b/services/agents.js
@@ -6,6 +6,12 @@ import { getImageUrl } from "../constants.js";
 
 const isAgent = item => item.prefab === "customplayertradable";
 
+const cleanAgentName = name => {
+    // Fix double spaces around pipe for items with incorrect Steam data
+    if (typeof name !== 'string') return name;
+    return name.replace(/\s*\|\s*/g, ' | ');
+};
+
 const parseItem = item => {
     const { collectionsBySkins, cdnImages } = state;
 
@@ -15,7 +21,7 @@ const parseItem = item => {
 
     return {
         id: `agent-${item.object_id}`,
-        name: $t(item.item_name),
+        name: cleanAgentName($t(item.item_name)),
         description: $t(item.item_description),
         def_index: item.object_id,
         rarity: {
@@ -34,7 +40,7 @@ const parseItem = item => {
                     ? $t("inv_filter_ct")
                     : $t("inv_filter_t"),
         },
-        market_hash_name: $t(item.item_name, true),
+        market_hash_name: cleanAgentName($t(item.item_name, true)),
         image,
         model_player: item.model_player ?? null,
 

--- a/services/collections.js
+++ b/services/collections.js
@@ -6,6 +6,12 @@ import { getImageUrl } from "../constants.js";
 
 const isCollection = item => item.is_collection !== undefined;
 
+const cleanItemName = name => {
+    // Fix double spaces around pipe for items with incorrect Steam data
+    if (typeof name !== 'string') return name;
+    return name.replace(/\s*\|\s*/g, ' | ');
+};
+
 const isSelfOpeningCollection = item => {
     if (item.item_name === undefined) return false;
 
@@ -48,11 +54,11 @@ const parseItem = item => {
         name: item.name_force ? $t(item.name_force) : $t(item.name),
         crates: (cratesByCollections?.[item.name.replace("#CSGO_", "")] ?? []).map(i => ({
             ...i,
-            name: $t(i.name),
+            name: cleanItemName($t(i.name)),
         })),
         contains: skinsByCollections?.[item.name.replace("#CSGO_", "")].map(i => ({
             ...i,
-            name: i.name instanceof Object ? `${$t(i.name.weapon)} | ${$t(i.name.pattern)}` : $t(i.name),
+            name: i.name instanceof Object ? cleanItemName(`${$t(i.name.weapon)} | ${$t(i.name.pattern)}`) : cleanItemName($t(i.name)),
             rarity: {
                 id: i.rarity,
                 name: $t(i.rarity),
@@ -81,7 +87,7 @@ const parseItemSelfOpening = item => {
         crates: [],
         contains: (skinsByCollections?.[item.name] ?? []).map(i => ({
             ...i,
-            name: $t(i.name),
+            name: cleanItemName($t(i.name)),
             rarity: {
                 id: i.rarity,
                 name: $t(i.rarity),

--- a/services/crates.js
+++ b/services/crates.js
@@ -5,6 +5,12 @@ import specialNotes from "../utils/specialNotes.json" with { type: "json" };
 import { getRarityColor } from "../utils/index.js";
 import { getImageUrl } from "../constants.js";
 
+const cleanItemName = name => {
+    // Fix double spaces around pipe for items with incorrect Steam data
+    if (typeof name !== 'string') return name;
+    return name.replace(/\s*\|\s*/g, ' | ');
+};
+
 const isCrate = item => {
     if (item.item_name === undefined) return false;
 
@@ -138,7 +144,7 @@ const parseItem = (item, prefabs) => {
         contains: (skinsByCrates?.[item.tags?.ItemSet?.tag_value] ?? skinsByCrates?.[keyLootList] ?? []).map(
             i => ({
                 ...i,
-                name: i.name instanceof Object ? `${$t(i.name.weapon)} | ${$t(i.name.pattern)}` : $t(i.name),
+                name: i.name instanceof Object ? cleanItemName(`${$t(i.name.weapon)} | ${$t(i.name.pattern)}`) : cleanItemName($t(i.name)),
                 rarity: {
                     id: i.rarity,
                     name: $t(i.rarity),

--- a/services/stickerSlabs.js
+++ b/services/stickerSlabs.js
@@ -5,6 +5,12 @@ import specialNotes from "../utils/specialNotes.json" with { type: "json" };
 import { getRarityColor } from "../utils/index.js";
 import { getImageUrl } from "../constants.js";
 
+const cleanItemName = name => {
+    // Fix double spaces around pipe for items with incorrect Steam data
+    if (typeof name !== 'string') return name;
+    return name.replace(/\s*\|\s*/g, ' | ');
+};
+
 const isSticker = item => {
     if (item.sticker_material === undefined) {
         return false;
@@ -144,7 +150,7 @@ const getMarketHashName = item => {
         return null;
     }
 
-    return `${$t("keychain_kc_sticker_display_case", true)} | ${$t(item.item_name, true)}`;
+    return cleanItemName(`${$t("keychain_kc_sticker_display_case", true)} | ${$t(item.item_name, true)}`);
 };
 
 const parseItem = item => {
@@ -161,7 +167,7 @@ const parseItem = item => {
 
     return {
         id: `sticker_slab-${item.object_id}`,
-        name: `${$t("keychain_kc_sticker_display_case")} | ${$t(item.item_name)}`,
+        name: cleanItemName(`${$t("keychain_kc_sticker_display_case")} | ${$t(item.item_name)}`),
         description: getDescription(),
         def_index: item.object_id,
         rarity: item.item_rarity

--- a/services/stickers.js
+++ b/services/stickers.js
@@ -5,6 +5,12 @@ import specialNotes from "../utils/specialNotes.json" with { type: "json" };
 import { getRarityColor } from "../utils/index.js";
 import { getImageUrl } from "../constants.js";
 
+const cleanStickerName = name => {
+    // Fix double spaces around pipe for items with incorrect Steam data
+    if (typeof name !== 'string') return name;
+    return name.replace(/\s*\|\s*/g, ' | ');
+};
+
 const isSticker = item => {
     if (item.sticker_material === undefined) {
         return false;
@@ -153,7 +159,7 @@ const getMarketHashName = item => {
         return null;
     }
 
-    return `${$t("csgo_tool_sticker", true)} | ${$t(item.item_name, true)}`;
+    return cleanStickerName(`${$t("csgo_tool_sticker", true)} | ${$t(item.item_name, true)}`);
 };
 
 const parseItem = item => {
@@ -170,7 +176,7 @@ const parseItem = item => {
 
     return {
         id: `sticker-${item.object_id}`,
-        name: `${$t("csgo_tool_sticker")} | ${$t(item.item_name)}`,
+        name: cleanStickerName(`${$t("csgo_tool_sticker")} | ${$t(item.item_name)}`),
         description: getDescription(item),
         def_index: item.object_id,
         rarity: item.item_rarity


### PR DESCRIPTION
## Problem
Some item names in the JSON files contained "  | " (double space before pipe) instead of " | " (single space). This was due to inconsistencies in the source repo's data, namely:

```
1. `"StickerKit_eslkatowice2015_ninjasinpyjamas": "Ninjas in Pyjamas  | Katowice 2015"`,
2. `"StickerKit_eslkatowice2015_pentasports": "PENTA Sports  | Katowice 2015"`,
3. `"StickerKit_eslkatowice2015_voxeminor": "Vox Eminor  | Katowice 2015"`,
4. `"StickerKit_columbus2016_signature_adrenkz": "AdreN  | MLG Columbus 2016"`,
5. `"StickerKit_columbus2016_signature_adrenkz_foil": "AdreN (Foil)  | MLG Columbus 2016"`,
6. `"StickerKit_columbus2016_signature_adrenkz_gold": "AdreN (Gold)  | MLG Columbus 2016"`,
7. `"StickerKit_london2018_signature_nikodk": "niko  | London 2018"`,
8. `"StickerKit_london2018_signature_nikodk_foil": "niko (Foil)  | London 2018"`,
9. `"StickerKit_london2018_signature_nikodk_gold": "niko (Gold)  | London 2018",
10. `"StickerKit_paris2023_signature_nikodk": "niko  | Paris 2023"`,
11. `"StickerKit_paris2023_signature_nikodk_glitter": "niko (Glitter)  | Paris 2023"`,
12. `"StickerKit_paris2023_signature_nikodk_holo": "niko (Holo)  | Paris 2023"`,
13. `"StickerKit_paris2023_signature_nikodk_gold": "niko (Gold)  | Paris 2023"`,
14. `"CSGO_CustomPlayer_tm_leet_variantg": "Ground Rebel  | Elite Crew"`,
15. `"CSGO_CustomPlayer_ctm_fbi_varianth": "Michael Syfers  | FBI Sniper"`,
```

## Solution
Added normalization functions to clean up item names:
- `services/agents.js` - clean agent names
- `services/collections.js` - clean collection names
- `services/crates.js` - clean crate names
- `services/stickers.js` - clean sticker names
- `services/stickerSlabs.js` - clean sticker slab names

All items now display with consistent " | " formatting.
