### PR TITLE
feat: add id field to highlights original object

### DIFF
--- a/services/highlights.js
+++ b/services/highlights.js
@@ -41,6 +41,7 @@ const parseItem = item => {
         // TODO: would be great to have chinese thumbnail as well
         thumbnail: getThumbnail(),
         original: {
+            id: item.id,
             image_inventory: item.image_inventory,
         },
     };


### PR DESCRIPTION
## Description

This adds an `id` field to the `original` object for highlight reels, preserving the original highlight identifier from the game files. 

The `image_inventory` field only identifies the tournament, but the original `id` provides a non-numerical value sourced from the game's files themselves that meaningfully differentiates individual highlights within the same tournament.


## Example

Before:
```json
"original": {
  "image_inventory": "econ/keychains/aus2025/kc_aus2025"
}
```

After:
```json
"original": {
  "id": "aus2025_chopper2kvsmouzonmirage1",
  "image_inventory": "econ/keychains/aus2025/kc_aus2025"
}
```
