### PR TITLE
fix: correct def_index for Remove Keychain Tool Pack (65 → 4950)

### DIFF
--- a/public/api/en/tools.json
+++ b/public/api/en/tools.json
@@ -34,7 +34,7 @@
   "name": "Charm Detachments",
   "description": "Select a weapon with an attached charm. Using a Charm Detachment will detach the charm and return it to your inventory.",
   "image": "https://community.akamai.steamstatic.com/economy/image/i0CoZ81Ui0m-9KwlBY1L_18myuGuq1wfhWSaZgMttyVfPaERSR0Wqmu7LAocGJG51EejH_3R2smpNHKZ2kRw-Yji72bzThL9oYbh_ikVv6qqPPQ0JaOXCmWRl7shtbhsFnHlkxl16miGy477dnmQb1R2DpBzF_lK7EckGgI0TA",
-  "def_index": "65",
+  "def_index": "4950",
   "original": {
    "image_inventory": "econ/tools/keychain_remove_tool"
   }

--- a/public/api/zh-CN/tools.json
+++ b/public/api/zh-CN/tools.json
@@ -34,7 +34,7 @@
   "name": "挂件拆卸器",
   "description": "选择一把已装配挂件的武器。使用挂件拆卸器拆掉挂件并将其返还到你的库存。",
   "image": "https://community.akamai.steamstatic.com/economy/image/i0CoZ81Ui0m-9KwlBY1L_18myuGuq1wfhWSaZgMttyVfPaERSR0Wqmu7LAocGJG51EejH_3R2smpNHKZ2kRw-Yji72bzThL9oYbh_ikVv6qqPPQ0JaOXCmWRl7shtbhsFnHlkxl16miGy477dnmQb1R2DpBzF_lK7EckGgI0TA",
-  "def_index": "65",
+  "def_index": "4950",
   "original": {
    "image_inventory": "econ/tools/keychain_remove_tool"
   }

--- a/services/tools.js
+++ b/services/tools.js
@@ -45,7 +45,7 @@ export const getTools = () => {
             image:
                 cdnImages["econ/tools/keychain_remove_tool"] ??
                 getImageUrl("econ/tools/keychain_remove_tool"),
-            def_index: "65",
+            def_index: "4950",
             original: {
                 image_inventory: "econ/tools/keychain_remove_tool",
             },


### PR DESCRIPTION
The hardcoded def_index "65" for the keychain remove tool does not match the actual def_index 4950 in items_game.txt. CS2 sends def_index=4950 in inventory items, making it impossible to resolve this item.